### PR TITLE
Chapter06/euroxrefURL, using http returns 301 Moved Permanently

### DIFF
--- a/06-money_converter/5_bank/ecbank/ecb.go
+++ b/06-money_converter/5_bank/ecbank/ecb.go
@@ -24,7 +24,7 @@ type Client struct {
 
 // FetchExchangeRate fetches today's ExchangeRate and returns it.
 func (c Client) FetchExchangeRate(source, target money.Currency) (money.ExchangeRate, error) {
-	const euroxrefURL = "http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+	const euroxrefURL = "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
 
 	if c.url == "" {
 		c.url = euroxrefURL

--- a/06-money_converter/6_timeout/ecbank/ecb.go
+++ b/06-money_converter/6_timeout/ecbank/ecb.go
@@ -34,7 +34,7 @@ func NewClient(timeout time.Duration) Client {
 
 // FetchExchangeRate fetches today's ExchangeRate and returns it.
 func (c Client) FetchExchangeRate(source, target money.Currency) (money.ExchangeRate, error) {
-	const euroxrefURL = "http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+	const euroxrefURL = "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
 
 	resp, err := c.client.Get(euroxrefURL)
 	if err != nil {


### PR DESCRIPTION
use `https` instead, see: https://stackoverflow.com/a/54498335/15105469